### PR TITLE
Avoid collision of activity's request code

### DIFF
--- a/android/src/main/java/com/varunvairavan/fluttercardio/FlutterCardIoPlugin.java
+++ b/android/src/main/java/com/varunvairavan/fluttercardio/FlutterCardIoPlugin.java
@@ -21,7 +21,7 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
  * FlutterCardIoPlugin
  */
 public class FlutterCardIoPlugin implements MethodCallHandler, ActivityResultListener {
-    private static final int MY_SCAN_REQUEST_CODE = 100;
+    private static final int MY_SCAN_REQUEST_CODE = "flutter_card_io".hashCode();
 
     private final PluginRegistry.Registrar registrar;
     private Result pendingResult;

--- a/ios/flutter_card_io.podspec
+++ b/ios/flutter_card_io.podspec
@@ -16,6 +16,7 @@ CardIO flutter plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'CardIO'
+  s.static_framework = true
   s.ios.deployment_target = '8.0'
 end
 


### PR DESCRIPTION
The number 100 is too common and collide with another plugin
such as flutter_barcode_reader.

https://github.com/apptreesoftware/flutter_barcode_reader

The collision keep the plugin from handling activity result.

Use hashcode of package name to decrease the collision probability.