### PR TITLE
Fixed compatibility with latest cocoapods

### DIFF
--- a/ios/flutter_card_io.podspec
+++ b/ios/flutter_card_io.podspec
@@ -17,5 +17,6 @@ CardIO flutter plugin.
   s.dependency 'Flutter'
   s.dependency 'CardIO'
   s.ios.deployment_target = '8.0'
+  s.static_framework = true
 end
 


### PR DESCRIPTION
You are not able to use ios libs written in objective c and swift at the same time. 